### PR TITLE
Adding example launchd script for OSX

### DIFF
--- a/examples/crispyfi.plist
+++ b/examples/crispyfi.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key>
+            <string>crispyfi</string>
+        <key>ProgramArguments</key>
+            <array>
+                <string>/usr/local/bin/node</string>
+                <string>/usr/local/opt/crispyfi/index.js</string>
+            </array>
+        <key>RunAtLoad</key>
+            <true/>
+        <key>KeepAlive</key>
+            <true/>
+        <key>StandardErrorPath</key>
+            <string>/var/log/system.log</string>
+        <key>LaunchOnlyOnce</key>
+            <true/>
+        <key>WorkingDirectory</key>
+            <string>/usr/local/opt/crispyfi</string>
+    </dict>
+</plist>


### PR DESCRIPTION
Launch on start with OSX using:

```sh
$ launchctl load ~/Library/LaunchAgents/crispyfi.plist
```